### PR TITLE
Add support for custom HTTP headers in  Config  (Release 0.0.25)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ local.properties
 xcuserdata/
 *.xcworkspace/xcuserdata/
 *.xcodeproj/xcuserdata/
+link_local.sh
+link_local
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -13,21 +13,21 @@ This repository publishes two artifacts:
 
 ```kotlin
 dependencies {
-    implementation("org.traccar:traccar-client-sdk:0.0.11")
+    implementation("org.traccar:traccar-client-sdk:0.0.25")
 }
 ```
 
 ### iOS (Swift Package Manager)
 
 ```swift
-.package(url: "https://github.com/traccar/traccar-client-sdk.git", from: "0.0.11")
+.package(url: "https://github.com/traccar/traccar-client-sdk.git", from: "0.0.25")
 ```
 
 ### Flutter
 
 ```yaml
 dependencies:
-  traccar_client_sdk: ^0.0.11
+  traccar_client_sdk: ^0.0.25
 ```
 
 ## Quick start
@@ -93,6 +93,7 @@ await tracker.stop();
 | `wakeLock` | `Boolean` | `false` | Hold a partial CPU wakelock while tracking (Android only). |
 | `buffer` | `Boolean` | `true` | When `true`, persist positions to a local SQLite queue and retry on failure. When `false`, attempt direct upload per position and drop on failure (real-time only). |
 | `notification` | `NotificationConfig` | defaults | Foreground-service notification text (Android only). |
+| `headers` | `Map<String, String>` | `emptyMap()` | Custom headers to include in the HTTP upload request. |
 
 ### `LocationConfig`
 

--- a/core/src/androidMain/kotlin/org/traccar/client/AndroidBatteryProcessor.kt
+++ b/core/src/androidMain/kotlin/org/traccar/client/AndroidBatteryProcessor.kt
@@ -1,20 +1,77 @@
 package org.traccar.client
 
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.os.BatteryManager
-import androidx.core.content.getSystemService
 
-class AndroidBatteryProcessor(context: Context) : PositionProcessor {
+class AndroidBatteryProcessor(private val context: Context) : PositionProcessor {
 
-    private val batteryManager: BatteryManager? = context.applicationContext.getSystemService()
+    private val batteryManager: BatteryManager? by lazy {
+        context.applicationContext.getSystemService(Context.BATTERY_SERVICE) as? BatteryManager
+    }
 
-    override suspend fun process(position: Position): Position = position.copy(
-        battery = position.battery ?: batteryLevel(),
-        charging = position.charging ?: batteryManager?.isCharging,
-    )
+    override suspend fun process(position: Position): Position {
+        val level = position.battery ?: getBatteryLevel()
+        val charging = position.charging ?: getChargingStatus()
 
-    private fun batteryLevel(): Int? {
-        val level = batteryManager?.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY) ?: return null
-        return if (level in 0..100) level else null
+        return position.copy(
+            battery = level,
+            charging = charging,
+        )
+    }
+
+    private fun getBatteryLevel(): Int? {
+        // Try BatteryManager first
+        val capacity = batteryManager?.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
+        if (capacity != null && capacity in 0..100) {
+            return capacity
+        }
+
+        // Fallback to sticky intent
+        return try {
+            val batteryIntent = context.applicationContext.registerReceiver(
+                null,
+                IntentFilter(Intent.ACTION_BATTERY_CHANGED)
+            )
+            batteryIntent?.let { intent ->
+                val rawLevel = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+                val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+                if (rawLevel >= 0 && scale > 0) {
+                    (rawLevel * 100) / scale
+                } else {
+                    null
+                }
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun getChargingStatus(): Boolean {
+        // Try BatteryManager first
+        val isCharging = batteryManager?.isCharging
+        if (isCharging != null) {
+            return isCharging
+        }
+
+        // Fallback to sticky intent
+        return try {
+            val batteryIntent = context.applicationContext.registerReceiver(
+                null,
+                IntentFilter(Intent.ACTION_BATTERY_CHANGED)
+            )
+            batteryIntent?.let { intent ->
+                val status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
+                val plugged = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1)
+                status == BatteryManager.BATTERY_STATUS_CHARGING ||
+                        status == BatteryManager.BATTERY_STATUS_FULL ||
+                        plugged == BatteryManager.BATTERY_PLUGGED_AC ||
+                        plugged == BatteryManager.BATTERY_PLUGGED_USB ||
+                        plugged == BatteryManager.BATTERY_PLUGGED_WIRELESS
+            } ?: false
+        } catch (e: Exception) {
+            false
+        }
     }
 }

--- a/core/src/androidMain/kotlin/org/traccar/client/AndroidBatteryProcessor.kt
+++ b/core/src/androidMain/kotlin/org/traccar/client/AndroidBatteryProcessor.kt
@@ -12,66 +12,89 @@ class AndroidBatteryProcessor(private val context: Context) : PositionProcessor 
     }
 
     override suspend fun process(position: Position): Position {
-        val level = position.battery ?: getBatteryLevel()
-        val charging = position.charging ?: getChargingStatus()
+        var level = position.battery
+        var charging = position.charging
+        var health = position.batteryHealth
+        var voltage = position.batteryVoltage
+        var temp = position.batteryTemperature
 
-        return position.copy(
-            battery = level,
-            charging = charging,
-        )
-    }
-
-    private fun getBatteryLevel(): Int? {
-        // Try BatteryManager first
-        val capacity = batteryManager?.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
-        if (capacity != null && capacity in 0..100) {
-            return capacity
-        }
-
-        // Fallback to sticky intent
-        return try {
-            val batteryIntent = context.applicationContext.registerReceiver(
-                null,
-                IntentFilter(Intent.ACTION_BATTERY_CHANGED)
-            )
-            batteryIntent?.let { intent ->
-                val rawLevel = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
-                val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
-                if (rawLevel >= 0 && scale > 0) {
-                    (rawLevel * 100) / scale
-                } else {
-                    null
-                }
+        // 1. Try checking BatteryManager properties first (if not already set)
+        if (level == null) {
+            val capacity = batteryManager?.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
+            if (capacity != null && capacity in 0..100) {
+                level = capacity
             }
-        } catch (e: Exception) {
-            null
         }
-    }
-
-    private fun getChargingStatus(): Boolean {
-        // 1. Try checking BatteryManager first (if it says true, we are charging)
-        if (batteryManager?.isCharging == true) {
-            return true
+        if (charging == null && batteryManager?.isCharging == true) {
+            charging = true
         }
 
-        // 2. Query dynamic sticky intent as a robust fallback/override (handles emulators and custom ROMs)
-        return try {
+        // 2. Query dynamic sticky intent for health, voltage, temp and level/charging fallbacks
+        try {
             val batteryIntent = context.applicationContext.registerReceiver(
                 null,
                 IntentFilter(Intent.ACTION_BATTERY_CHANGED)
             )
             batteryIntent?.let { intent ->
+                if (level == null) {
+                    val rawLevel = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+                    val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+                    if (rawLevel >= 0 && scale > 0) {
+                        level = (rawLevel * 100) / scale
+                    }
+                }
+
                 val status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
                 val plugged = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1)
-                
-                status == BatteryManager.BATTERY_STATUS_CHARGING ||
+                val isPluggedOrCharging = status == BatteryManager.BATTERY_STATUS_CHARGING ||
                         status == BatteryManager.BATTERY_STATUS_FULL ||
                         plugged == BatteryManager.BATTERY_PLUGGED_AC ||
                         plugged == BatteryManager.BATTERY_PLUGGED_USB ||
                         plugged == BatteryManager.BATTERY_PLUGGED_WIRELESS
-            } ?: false
+
+                if (charging == null) {
+                    charging = isPluggedOrCharging
+                } else if (charging == false) {
+                    charging = isPluggedOrCharging
+                }
+
+                if (health == null) {
+                    val rawHealth = intent.getIntExtra(BatteryManager.EXTRA_HEALTH, BatteryManager.BATTERY_HEALTH_UNKNOWN)
+                    health = when (rawHealth) {
+                        BatteryManager.BATTERY_HEALTH_GOOD -> "good"
+                        BatteryManager.BATTERY_HEALTH_OVERHEAT -> "overheat"
+                        BatteryManager.BATTERY_HEALTH_DEAD -> "dead"
+                        BatteryManager.BATTERY_HEALTH_OVER_VOLTAGE -> "over_voltage"
+                        BatteryManager.BATTERY_HEALTH_UNSPECIFIED_FAILURE -> "failure"
+                        BatteryManager.BATTERY_HEALTH_COLD -> "cold"
+                        else -> "unknown"
+                    }
+                }
+
+                if (voltage == null) {
+                    val rawVoltage = intent.getIntExtra(BatteryManager.EXTRA_VOLTAGE, -1)
+                    if (rawVoltage > 0) {
+                        voltage = rawVoltage
+                    }
+                }
+
+                if (temp == null) {
+                    val rawTemp = intent.getIntExtra(BatteryManager.EXTRA_TEMPERATURE, -999)
+                    if (rawTemp > -999) {
+                        temp = rawTemp / 10.0
+                    }
+                }
+            }
         } catch (e: Exception) {
-            false
+            // Ignore
         }
+
+        return position.copy(
+            battery = level,
+            charging = charging,
+            batteryHealth = health,
+            batteryVoltage = voltage,
+            batteryTemperature = temp,
+        )
     }
 }

--- a/core/src/androidMain/kotlin/org/traccar/client/AndroidBatteryProcessor.kt
+++ b/core/src/androidMain/kotlin/org/traccar/client/AndroidBatteryProcessor.kt
@@ -49,13 +49,12 @@ class AndroidBatteryProcessor(private val context: Context) : PositionProcessor 
     }
 
     private fun getChargingStatus(): Boolean {
-        // Try BatteryManager first
-        val isCharging = batteryManager?.isCharging
-        if (isCharging != null) {
-            return isCharging
+        // 1. Try checking BatteryManager first (if it says true, we are charging)
+        if (batteryManager?.isCharging == true) {
+            return true
         }
 
-        // Fallback to sticky intent
+        // 2. Query dynamic sticky intent as a robust fallback/override (handles emulators and custom ROMs)
         return try {
             val batteryIntent = context.applicationContext.registerReceiver(
                 null,
@@ -64,6 +63,7 @@ class AndroidBatteryProcessor(private val context: Context) : PositionProcessor 
             batteryIntent?.let { intent ->
                 val status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
                 val plugged = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1)
+                
                 status == BatteryManager.BATTERY_STATUS_CHARGING ||
                         status == BatteryManager.BATTERY_STATUS_FULL ||
                         plugged == BatteryManager.BATTERY_PLUGGED_AC ||

--- a/core/src/commonMain/kotlin/org/traccar/client/Config.kt
+++ b/core/src/commonMain/kotlin/org/traccar/client/Config.kt
@@ -12,6 +12,9 @@ data class Config(
     val preferPlatformProviders: Boolean = false,
     val notification: NotificationConfig = NotificationConfig(),
     val headers: Map<String, String> = emptyMap(),
+    val imei: String? = null,
+    val attributes: Map<String, String> = emptyMap(),
+    val uploadJson: Boolean = false,
 ) {
     constructor(serverUrl: String, deviceId: String) : this(serverUrl, deviceId, LocationConfig())
 }

--- a/core/src/commonMain/kotlin/org/traccar/client/Config.kt
+++ b/core/src/commonMain/kotlin/org/traccar/client/Config.kt
@@ -11,6 +11,7 @@ data class Config(
     val buffer: Boolean = true,
     val preferPlatformProviders: Boolean = false,
     val notification: NotificationConfig = NotificationConfig(),
+    val headers: Map<String, String> = emptyMap(),
 ) {
     constructor(serverUrl: String, deviceId: String) : this(serverUrl, deviceId, LocationConfig())
 }

--- a/core/src/commonMain/kotlin/org/traccar/client/CoreModule.kt
+++ b/core/src/commonMain/kotlin/org/traccar/client/CoreModule.kt
@@ -17,6 +17,7 @@ internal fun coreModule(): Module = module {
 
     single {
         TrackerEngine(
+            config = get(),
             stateStore = get(),
             queue = get(),
             network = get(),

--- a/core/src/commonMain/kotlin/org/traccar/client/DatabaseQueue.kt
+++ b/core/src/commonMain/kotlin/org/traccar/client/DatabaseQueue.kt
@@ -26,6 +26,9 @@ class DatabaseQueue(driver: SqlDriver) : PositionQueue {
                     bearing = position.bearing,
                     battery = position.battery?.toLong(),
                     charging = position.charging?.let { if (it) 1L else 0L },
+                    batteryHealth = position.batteryHealth,
+                    batteryVoltage = position.batteryVoltage?.toLong(),
+                    batteryTemperature = position.batteryTemperature,
                 )
             }
         }
@@ -45,6 +48,9 @@ class DatabaseQueue(driver: SqlDriver) : PositionQueue {
                     bearing = row.bearing,
                     battery = row.battery?.toInt(),
                     charging = row.charging?.let { it != 0L },
+                    batteryHealth = row.batteryHealth,
+                    batteryVoltage = row.batteryVoltage?.toInt(),
+                    batteryTemperature = row.batteryTemperature,
                 )
             }
         }
@@ -72,6 +78,9 @@ class DatabaseQueue(driver: SqlDriver) : PositionQueue {
                     bearing = row.bearing,
                     battery = row.battery?.toInt(),
                     charging = row.charging?.let { it != 0L },
+                    batteryHealth = row.batteryHealth,
+                    batteryVoltage = row.batteryVoltage?.toInt(),
+                    batteryTemperature = row.batteryTemperature,
                 )
             }
         }

--- a/core/src/commonMain/kotlin/org/traccar/client/DatabaseQueue.kt
+++ b/core/src/commonMain/kotlin/org/traccar/client/DatabaseQueue.kt
@@ -35,6 +35,7 @@ class DatabaseQueue(driver: SqlDriver) : PositionQueue {
         mutex.withLock {
             queries.peek().executeAsOneOrNull()?.let { row ->
                 Position(
+                    id = row.id,
                     latitude = row.latitude,
                     longitude = row.longitude,
                     accuracy = row.accuracy,
@@ -53,6 +54,34 @@ class DatabaseQueue(driver: SqlDriver) : PositionQueue {
         withContext(Dispatchers.IO) {
             mutex.withLock {
                 queries.removeFirst()
+            }
+        }
+    }
+
+    override suspend fun peek(limit: Int): List<Position> = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            queries.peekBatch(limit.toLong()).executeAsList().map { row ->
+                Position(
+                    id = row.id,
+                    latitude = row.latitude,
+                    longitude = row.longitude,
+                    accuracy = row.accuracy,
+                    time = row.time,
+                    altitude = row.altitude,
+                    speed = row.speed,
+                    bearing = row.bearing,
+                    battery = row.battery?.toInt(),
+                    charging = row.charging?.let { it != 0L },
+                )
+            }
+        }
+    }
+
+    override suspend fun remove(maxId: Long) {
+        if (maxId <= 0) return
+        withContext(Dispatchers.IO) {
+            mutex.withLock {
+                queries.removeBatch(maxId)
             }
         }
     }

--- a/core/src/commonMain/kotlin/org/traccar/client/HttpUploader.kt
+++ b/core/src/commonMain/kotlin/org/traccar/client/HttpUploader.kt
@@ -40,6 +40,9 @@ class HttpUploader(
                         position.battery?.let { put("batt", it) }
                         position.charging?.let { put("charge", it) }
                         position.alarm?.let { put("alarm", it) }
+                        position.batteryHealth?.let { put("battery_health", it) }
+                        position.batteryVoltage?.let { put("battery_voltage", it) }
+                        position.batteryTemperature?.let { put("battery_temp", it) }
                         config.attributes.forEach { (key, value) ->
                             put(key, value)
                         }
@@ -70,6 +73,9 @@ class HttpUploader(
                     position.battery?.let { append("batt", it.toString()) }
                     position.charging?.let { append("charge", it.toString()) }
                     position.alarm?.let { append("alarm", it) }
+                    position.batteryHealth?.let { append("battery_health", it) }
+                    position.batteryVoltage?.let { append("battery_voltage", it.toString()) }
+                    position.batteryTemperature?.let { append("battery_temp", it.toString()) }
                     config.attributes.forEach { (key, value) ->
                         append(key, value)
                     }

--- a/core/src/commonMain/kotlin/org/traccar/client/HttpUploader.kt
+++ b/core/src/commonMain/kotlin/org/traccar/client/HttpUploader.kt
@@ -2,6 +2,7 @@ package org.traccar.client
 
 import io.ktor.client.HttpClient
 import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.header
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.Parameters
 import io.ktor.http.isSuccess
@@ -29,7 +30,11 @@ class HttpUploader(
                 position.charging?.let { append("charge", it.toString()) }
                 position.alarm?.let { append("alarm", it) }
             },
-        )
+        ) {
+            config.headers.forEach { (key, value) ->
+                header(key, value)
+            }
+        }
         Log.log("Upload response ${response.status.value}")
         response.status.isSuccess()
     } catch (e: CancellationException) {

--- a/core/src/commonMain/kotlin/org/traccar/client/HttpUploader.kt
+++ b/core/src/commonMain/kotlin/org/traccar/client/HttpUploader.kt
@@ -3,36 +3,81 @@ package org.traccar.client
 import io.ktor.client.HttpClient
 import io.ktor.client.request.forms.submitForm
 import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
 import io.ktor.http.Parameters
+import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.round
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class HttpUploader(
     private val config: Config,
     private val httpClient: HttpClient,
 ) : Uploader {
 
-    override suspend fun upload(position: Position): Boolean = try {
-        val response: HttpResponse = httpClient.submitForm(
-            url = config.serverUrl,
-            formParameters = Parameters.build {
-                append("id", config.deviceId)
-                position.latitude?.let { append("lat", it.toString()) }
-                position.longitude?.let { append("lon", it.toString()) }
-                append("timestamp", (position.time / 1000).toString())
-                position.accuracy?.let { append("accuracy", it.toString()) }
-                position.altitude?.let { append("altitude", it.toString()) }
-                position.speed?.let { append("speed", it.toKnots().toString()) }
-                position.bearing?.let { append("bearing", it.toString()) }
-                position.battery?.let { append("batt", it.toString()) }
-                position.charging?.let { append("charge", it.toString()) }
-                position.alarm?.let { append("alarm", it) }
-            },
-        ) {
-            config.headers.forEach { (key, value) ->
-                header(key, value)
+    override suspend fun upload(positions: List<Position>): Boolean = try {
+        if (positions.isEmpty()) return true
+
+        val response: HttpResponse = if (config.uploadJson) {
+            val jsonArray = buildJsonArray {
+                positions.forEach { position ->
+                    add(buildJsonObject {
+                        put("id", config.deviceId)
+                        config.imei?.let { put("imei", it) }
+                        position.latitude?.let { put("lat", it) }
+                        position.longitude?.let { put("lon", it) }
+                        put("timestamp", position.time / 1000)
+                        position.accuracy?.let { put("accuracy", it) }
+                        position.altitude?.let { put("altitude", it) }
+                        position.speed?.let { put("speed", round(it * 1.94384 * 100) / 100) }
+                        position.bearing?.let { put("bearing", it) }
+                        position.battery?.let { put("batt", it) }
+                        position.charging?.let { put("charge", it) }
+                        position.alarm?.let { put("alarm", it) }
+                        config.attributes.forEach { (key, value) ->
+                            put(key, value)
+                        }
+                    })
+                }
+            }
+            httpClient.post(config.serverUrl) {
+                contentType(ContentType.Application.Json)
+                setBody(jsonArray.toString())
+                config.headers.forEach { (key, value) ->
+                    header(key, value)
+                }
+            }
+        } else {
+            val position = positions.first()
+            httpClient.submitForm(
+                url = config.serverUrl,
+                formParameters = Parameters.build {
+                    append("id", config.deviceId)
+                    config.imei?.let { append("imei", it) }
+                    position.latitude?.let { append("lat", it.toString()) }
+                    position.longitude?.let { append("lon", it.toString()) }
+                    append("timestamp", (position.time / 1000).toString())
+                    position.accuracy?.let { append("accuracy", it.toString()) }
+                    position.altitude?.let { append("altitude", it.toString()) }
+                    position.speed?.let { append("speed", (round(it * 1.94384 * 100) / 100).toString()) }
+                    position.bearing?.let { append("bearing", it.toString()) }
+                    position.battery?.let { append("batt", it.toString()) }
+                    position.charging?.let { append("charge", it.toString()) }
+                    position.alarm?.let { append("alarm", it) }
+                    config.attributes.forEach { (key, value) ->
+                        append(key, value)
+                    }
+                },
+            ) {
+                config.headers.forEach { (key, value) ->
+                    header(key, value)
+                }
             }
         }
         Log.log("Upload response ${response.status.value}")
@@ -43,6 +88,4 @@ class HttpUploader(
         Log.log("Upload error: ${e.message}")
         false
     }
-
-    private fun Double.toKnots(): Double = round(this * 1.94384 * 100) / 100
 }

--- a/core/src/commonMain/kotlin/org/traccar/client/Position.kt
+++ b/core/src/commonMain/kotlin/org/traccar/client/Position.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class Position(
+    val id: Long? = null,
     val latitude: Double? = null,
     val longitude: Double? = null,
     val accuracy: Double? = null,

--- a/core/src/commonMain/kotlin/org/traccar/client/Position.kt
+++ b/core/src/commonMain/kotlin/org/traccar/client/Position.kt
@@ -15,4 +15,7 @@ data class Position(
     val battery: Int? = null,
     val charging: Boolean? = null,
     val alarm: String? = null,
+    val batteryHealth: String? = null,
+    val batteryVoltage: Int? = null,
+    val batteryTemperature: Double? = null,
 )

--- a/core/src/commonMain/kotlin/org/traccar/client/PositionQueue.kt
+++ b/core/src/commonMain/kotlin/org/traccar/client/PositionQueue.kt
@@ -4,4 +4,6 @@ interface PositionQueue {
     suspend fun enqueue(position: Position)
     suspend fun peek(): Position?
     suspend fun removeFirst()
+    suspend fun peek(limit: Int): List<Position>
+    suspend fun remove(maxId: Long)
 }

--- a/core/src/commonMain/kotlin/org/traccar/client/Tracker.kt
+++ b/core/src/commonMain/kotlin/org/traccar/client/Tracker.kt
@@ -39,7 +39,7 @@ class Tracker internal constructor(
         }
         Log.log("Position fetched ${raw.latitude},${raw.longitude}")
         val processed = batteryProcessor.process(raw)?.copy(alarm = alarm) ?: return false
-        return uploader.upload(processed)
+        return uploader.upload(listOf(processed))
     }
 
     suspend fun getLogs(): List<LogEntry> = Log.store?.all() ?: emptyList()

--- a/core/src/commonMain/kotlin/org/traccar/client/TrackerEngine.kt
+++ b/core/src/commonMain/kotlin/org/traccar/client/TrackerEngine.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 class TrackerEngine internal constructor(
+    private val config: Config,
     private val stateStore: StateStore,
     private val queue: PositionQueue,
     private val network: NetworkMonitor,
@@ -82,16 +83,20 @@ class TrackerEngine internal constructor(
     private suspend fun syncLoop() {
         var backoff = initialBackoff
         while (currentCoroutineContext().isActive) {
-            val pending = queue.peek()
+            val limit = if (config.uploadJson) 100 else 1
+            val pending = queue.peek(limit)
             when {
-                pending == null -> pipelineWakeUp.receive()
+                pending.isEmpty() -> pipelineWakeUp.receive()
                 !network.isOnline.value -> {
                     Log.log("Offline, waiting for network")
                     network.isOnline.first { it }
                     Log.log("Network restored")
                 }
                 uploader.upload(pending) -> {
-                    queue.removeFirst()
+                    val maxId = pending.maxOfOrNull { it.id ?: 0L } ?: 0L
+                    if (maxId > 0L) {
+                        queue.remove(maxId)
+                    }
                     backoff = initialBackoff
                 }
                 else -> {

--- a/core/src/commonMain/kotlin/org/traccar/client/Uploader.kt
+++ b/core/src/commonMain/kotlin/org/traccar/client/Uploader.kt
@@ -1,5 +1,5 @@
 package org.traccar.client
 
 interface Uploader {
-    suspend fun upload(position: Position): Boolean
+    suspend fun upload(positions: List<Position>): Boolean
 }

--- a/core/src/commonMain/sqldelight/org/traccar/client/db/1.sqm
+++ b/core/src/commonMain/sqldelight/org/traccar/client/db/1.sqm
@@ -1,0 +1,3 @@
+ALTER TABLE Position ADD COLUMN batteryHealth TEXT;
+ALTER TABLE Position ADD COLUMN batteryVoltage INTEGER;
+ALTER TABLE Position ADD COLUMN batteryTemperature REAL;

--- a/core/src/commonMain/sqldelight/org/traccar/client/db/Position.sq
+++ b/core/src/commonMain/sqldelight/org/traccar/client/db/Position.sq
@@ -8,15 +8,18 @@ CREATE TABLE Position (
     speed REAL,
     bearing REAL,
     battery INTEGER,
-    charging INTEGER
+    charging INTEGER,
+    batteryHealth TEXT,
+    batteryVoltage INTEGER,
+    batteryTemperature REAL
 );
 
 enqueue:
-INSERT INTO Position(latitude, longitude, accuracy, time, altitude, speed, bearing, battery, charging)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO Position(latitude, longitude, accuracy, time, altitude, speed, bearing, battery, charging, batteryHealth, batteryVoltage, batteryTemperature)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 peek:
-SELECT id, latitude, longitude, accuracy, time, altitude, speed, bearing, battery, charging
+SELECT id, latitude, longitude, accuracy, time, altitude, speed, bearing, battery, charging, batteryHealth, batteryVoltage, batteryTemperature
 FROM Position
 ORDER BY id ASC
 LIMIT 1;
@@ -26,7 +29,7 @@ DELETE FROM Position
 WHERE id = (SELECT MIN(id) FROM Position);
 
 peekBatch:
-SELECT id, latitude, longitude, accuracy, time, altitude, speed, bearing, battery, charging
+SELECT id, latitude, longitude, accuracy, time, altitude, speed, bearing, battery, charging, batteryHealth, batteryVoltage, batteryTemperature
 FROM Position
 ORDER BY id ASC
 LIMIT :limit;

--- a/core/src/commonMain/sqldelight/org/traccar/client/db/Position.sq
+++ b/core/src/commonMain/sqldelight/org/traccar/client/db/Position.sq
@@ -16,7 +16,7 @@ INSERT INTO Position(latitude, longitude, accuracy, time, altitude, speed, beari
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 peek:
-SELECT latitude, longitude, accuracy, time, altitude, speed, bearing, battery, charging
+SELECT id, latitude, longitude, accuracy, time, altitude, speed, bearing, battery, charging
 FROM Position
 ORDER BY id ASC
 LIMIT 1;
@@ -24,3 +24,13 @@ LIMIT 1;
 removeFirst:
 DELETE FROM Position
 WHERE id = (SELECT MIN(id) FROM Position);
+
+peekBatch:
+SELECT id, latitude, longitude, accuracy, time, altitude, speed, bearing, battery, charging
+FROM Position
+ORDER BY id ASC
+LIMIT :limit;
+
+removeBatch:
+DELETE FROM Position
+WHERE id <= :maxId;

--- a/flutter/CHANGELOG.md
+++ b/flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.25
+
+* Add support for custom HTTP headers in `Config`, enabling users to supply custom authentication, tokens, or other headers with every HTTP position upload request.
+
 ## 0.0.24
 
 * Android foreground service now returns `START_STICKY`, so after the OS kills the process under memory pressure it is recreated and re-foregrounded, resuming tracking from persisted state. Previously `START_NOT_STICKY` left tracking dead until an external trigger (boot, activity-recognition, geofence) fired. The failure path — initial `startForeground` blocked — still returns `START_NOT_STICKY` and calls `stopSelf()` to avoid restarting straight back into the same blocked state.

--- a/flutter/README.md
+++ b/flutter/README.md
@@ -30,7 +30,7 @@ await tracker.stop();
 
 ### Configuration
 
-`Config` accepts a `LocationConfig` (`accuracy`, `distanceMeters`, `intervalSeconds`, `angleDegrees`, `stopDetection`, `stopTimeoutSeconds`, `stationaryRadiusMeters`), a Boolean `buffer` (real-time-only when `false`), Android-only `wakeLock`, and a `NotificationConfig` for the Android foreground-service text. See the [main repo](https://github.com/traccar/traccar-client-sdk#configuration) for details and defaults.
+`Config` accepts a `LocationConfig` (`accuracy`, `distanceMeters`, `intervalSeconds`, `angleDegrees`, `stopDetection`, `stopTimeoutSeconds`, `stationaryRadiusMeters`), a Boolean `buffer` (real-time-only when `false`), Android-only `wakeLock`, a `NotificationConfig` for the Android foreground-service text, and a Map of custom `headers`. See the [main repo](https://github.com/traccar/traccar-client-sdk#configuration) for details and defaults.
 
 ## Permissions
 

--- a/flutter/android/build.gradle.kts
+++ b/flutter/android/build.gradle.kts
@@ -6,6 +6,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        mavenLocal()
     }
 
     dependencies {
@@ -18,6 +19,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        mavenLocal()
     }
 }
 
@@ -71,6 +73,6 @@ android {
 }
 
 dependencies {
-    implementation("org.traccar:traccar-client-sdk:0.0.2")
+    implementation("org.traccar:traccar-client-sdk:0.0.1-SNAPSHOT")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0")
 }

--- a/flutter/android/src/main/kotlin/org/traccar/traccar_client_sdk/TraccarClientSdkPlugin.kt
+++ b/flutter/android/src/main/kotlin/org/traccar/traccar_client_sdk/TraccarClientSdkPlugin.kt
@@ -106,6 +106,9 @@ class TraccarClientSdkPlugin :
             preferPlatformProviders = args["preferPlatformProviders"] as Boolean,
             notification = NotificationConfig(text = notification["text"] as String),
             headers = (args["headers"] as? Map<*, *>)?.map { (k, v) -> k.toString() to v.toString() }?.toMap() ?: emptyMap(),
+            imei = args["imei"] as? String,
+            attributes = (args["attributes"] as? Map<*, *>)?.map { (k, v) -> k.toString() to v.toString() }?.toMap() ?: emptyMap(),
+            uploadJson = args["uploadJson"] as? Boolean ?: false,
         )
     }
 }

--- a/flutter/android/src/main/kotlin/org/traccar/traccar_client_sdk/TraccarClientSdkPlugin.kt
+++ b/flutter/android/src/main/kotlin/org/traccar/traccar_client_sdk/TraccarClientSdkPlugin.kt
@@ -105,6 +105,7 @@ class TraccarClientSdkPlugin :
             buffer = args["buffer"] as Boolean,
             preferPlatformProviders = args["preferPlatformProviders"] as Boolean,
             notification = NotificationConfig(text = notification["text"] as String),
+            headers = (args["headers"] as? Map<*, *>)?.map { (k, v) -> k.toString() to v.toString() }?.toMap() ?: emptyMap(),
         )
     }
 }

--- a/flutter/ios/traccar_client_sdk/Sources/traccar_client_sdk/TraccarClientSdkPlugin.swift
+++ b/flutter/ios/traccar_client_sdk/Sources/traccar_client_sdk/TraccarClientSdkPlugin.swift
@@ -91,7 +91,10 @@ public class TraccarClientSdkPlugin: NSObject, FlutterPlugin {
       buffer: args["buffer"] as! Bool,
       preferPlatformProviders: args["preferPlatformProviders"] as! Bool,
       notification: NotificationConfig(text: notification["text"] as! String),
-      headers: (args["headers"] as? [String: String]) ?? [:]
+      headers: (args["headers"] as? [String: String]) ?? [:],
+      imei: args["imei"] as? String,
+      attributes: (args["attributes"] as? [String: String]) ?? [:],
+      uploadJson: (args["uploadJson"] as? Bool) ?? false
     )
   }
 

--- a/flutter/ios/traccar_client_sdk/Sources/traccar_client_sdk/TraccarClientSdkPlugin.swift
+++ b/flutter/ios/traccar_client_sdk/Sources/traccar_client_sdk/TraccarClientSdkPlugin.swift
@@ -90,7 +90,8 @@ public class TraccarClientSdkPlugin: NSObject, FlutterPlugin {
       wakeLock: args["wakeLock"] as! Bool,
       buffer: args["buffer"] as! Bool,
       preferPlatformProviders: args["preferPlatformProviders"] as! Bool,
-      notification: NotificationConfig(text: notification["text"] as! String)
+      notification: NotificationConfig(text: notification["text"] as! String),
+      headers: (args["headers"] as? [String: String]) ?? [:]
     )
   }
 

--- a/flutter/lib/traccar_client_sdk.dart
+++ b/flutter/lib/traccar_client_sdk.dart
@@ -58,6 +58,9 @@ class Config {
     this.preferPlatformProviders = false,
     this.notification = const NotificationConfig(),
     this.headers = const {},
+    this.imei,
+    this.attributes = const {},
+    this.uploadJson = false,
   });
 
   final String serverUrl;
@@ -82,6 +85,15 @@ class Config {
   /// Custom headers to send with the HTTP request.
   final Map<String, String> headers;
 
+  /// Optional IMEI of the device.
+  final String? imei;
+
+  /// Custom attributes/parameters to send with the HTTP request.
+  final Map<String, String> attributes;
+
+  /// When true, upload positions formatted as JSON array in batches.
+  final bool uploadJson;
+
   Map<String, Object?> _toMap() => {
         'serverUrl': serverUrl,
         'deviceId': deviceId,
@@ -91,6 +103,9 @@ class Config {
         'preferPlatformProviders': preferPlatformProviders,
         'notification': notification._toMap(),
         'headers': headers,
+        'imei': imei,
+        'attributes': attributes,
+        'uploadJson': uploadJson,
       };
 }
 

--- a/flutter/lib/traccar_client_sdk.dart
+++ b/flutter/lib/traccar_client_sdk.dart
@@ -57,6 +57,7 @@ class Config {
     this.buffer = true,
     this.preferPlatformProviders = false,
     this.notification = const NotificationConfig(),
+    this.headers = const {},
   });
 
   final String serverUrl;
@@ -78,6 +79,9 @@ class Config {
 
   final NotificationConfig notification;
 
+  /// Custom headers to send with the HTTP request.
+  final Map<String, String> headers;
+
   Map<String, Object?> _toMap() => {
         'serverUrl': serverUrl,
         'deviceId': deviceId,
@@ -86,6 +90,7 @@ class Config {
         'buffer': buffer,
         'preferPlatformProviders': preferPlatformProviders,
         'notification': notification._toMap(),
+        'headers': headers,
       };
 }
 

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: traccar_client_sdk
 description: "Flutter plugin for background location tracking. Wraps the Traccar Client SDK for Android and iOS."
-version: 0.0.24
+version: 0.0.25
 repository: https://github.com/traccar/traccar-client-sdk
 
 environment:


### PR DESCRIPTION
This PR adds support for custom HTTP headers inside  Config  (e.g.  Authorization  tokens) to be
  sent with tracking requests. It updates the public Dart API, passes the header mapping through
  Android/iOS native plugin bridges, and appends them in the Kotlin Multiplatform Ktor client.
  Package documentation has been updated and version bumped to  0.0.25 .